### PR TITLE
feat: Add isConnectable support for Android API 26+

### DIFF
--- a/android/library/src/main/java/com/polidea/multiplatformbleadapter/BleModule.java
+++ b/android/library/src/main/java/com/polidea/multiplatformbleadapter/BleModule.java
@@ -99,6 +99,12 @@ public class BleModule implements BleAdapter {
     @Nullable
     private Subscription adapterStateChangesSubscription;
 
+    @Nullable
+    private android.bluetooth.le.BluetoothLeScanner nativeScanner;
+
+    @Nullable
+    private com.polidea.multiplatformbleadapter.utils.NativeScanCallbackWrapper nativeScanCallback;
+
     private RxBleDeviceToDeviceMapper rxBleDeviceToDeviceMapper = new RxBleDeviceToDeviceMapper();
 
     private RxScanResultToScanResultMapper rxScanResultToScanResultMapper = new RxScanResultToScanResultMapper();
@@ -246,6 +252,19 @@ public class BleModule implements BleAdapter {
             scanSubscription.unsubscribe();
             scanSubscription = null;
         }
+
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
+            if (nativeScanner != null && nativeScanCallback != null) {
+                try {
+                    nativeScanner.stopScan(nativeScanCallback);
+                } catch (Exception ignored) {
+                }
+                nativeScanner = null;
+                nativeScanCallback = null;
+            }
+        }
+
+        com.polidea.multiplatformbleadapter.utils.IsConnectableCache.getInstance().clear();
     }
 
     @Override
@@ -1329,6 +1348,34 @@ public class BleModule implements BleAdapter {
         ScanFilter[] filters = new ScanFilter[length];
         for (int i = 0; i < length; i++) {
             filters[i] = new ScanFilter.Builder().setServiceUuid(ParcelUuid.fromString(uuids[i].toString())).build();
+        }
+
+        // Start native scanner to capture isConnectable (API 26+)
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O && bluetoothAdapter != null) {
+            try {
+                nativeScanner = bluetoothAdapter.getBluetoothLeScanner();
+                if (nativeScanner != null) {
+                    nativeScanCallback = new com.polidea.multiplatformbleadapter.utils.NativeScanCallbackWrapper();
+
+                    android.bluetooth.le.ScanSettings nativeSettings = new android.bluetooth.le.ScanSettings.Builder()
+                            .setScanMode(scanMode)
+                            .setCallbackType(callbackType)
+                            .build();
+
+                    List<android.bluetooth.le.ScanFilter> nativeFilters = new ArrayList<>();
+                    for (ScanFilter filter : filters) {
+                        android.bluetooth.le.ScanFilter.Builder nativeFilterBuilder = new android.bluetooth.le.ScanFilter.Builder();
+                        if (filter.getServiceUuid() != null) {
+                            nativeFilterBuilder.setServiceUuid(filter.getServiceUuid());
+                        }
+                        nativeFilters.add(nativeFilterBuilder.build());
+                    }
+
+                    nativeScanner.startScan(nativeFilters, nativeSettings, nativeScanCallback);
+                }
+            } catch (Exception e) {
+                // Don't fail the scan if native scanner fails
+            }
         }
 
         scanSubscription = rxBleClient

--- a/android/library/src/main/java/com/polidea/multiplatformbleadapter/ScanResult.java
+++ b/android/library/src/main/java/com/polidea/multiplatformbleadapter/ScanResult.java
@@ -10,13 +10,16 @@ public class ScanResult {
     private String deviceName;
     private int rssi;
     private int mtu;
+    // Nullable because older Android APIs (<26) and older rxandroidble versions may
+    // not expose this.
     @Nullable
-    private boolean isConnectable;
+    private Boolean isConnectable;
     @Nullable
     private UUID[] overflowServiceUUIDs;
     private AdvertisementData advertisementData;
 
-    public ScanResult(String deviceId, String deviceName, int rssi, int mtu, boolean isConnectable, UUID[] overflowServiceUUIDs, AdvertisementData advertisementData) {
+    public ScanResult(String deviceId, String deviceName, int rssi, int mtu, @Nullable Boolean isConnectable,
+            UUID[] overflowServiceUUIDs, AdvertisementData advertisementData) {
         this.deviceId = deviceId;
         this.deviceName = deviceName;
         this.rssi = rssi;
@@ -58,11 +61,16 @@ public class ScanResult {
         this.mtu = mtu;
     }
 
-    public boolean isConnectable() {
+    // Both getters provided for FlutterBleLib reflection compatibility
+    public Boolean isConnectable() {
         return isConnectable;
     }
 
-    public void setConnectable(boolean connectable) {
+    public Boolean getIsConnectable() {
+        return isConnectable;
+    }
+
+    public void setConnectable(@Nullable Boolean connectable) {
         isConnectable = connectable;
     }
 

--- a/android/library/src/main/java/com/polidea/multiplatformbleadapter/utils/IsConnectableCache.java
+++ b/android/library/src/main/java/com/polidea/multiplatformbleadapter/utils/IsConnectableCache.java
@@ -1,0 +1,53 @@
+package com.polidea.multiplatformbleadapter.utils;
+
+import android.support.annotation.Nullable;
+
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * Cache for storing isConnectable information from native Android ScanResults.
+ * This works around the limitation that RxAndroidBle doesn't expose the native ScanResult.
+ */
+public class IsConnectableCache {
+    private static final IsConnectableCache INSTANCE = new IsConnectableCache();
+    private final ConcurrentHashMap<String, Boolean> cache = new ConcurrentHashMap<>();
+    private final ConcurrentHashMap<String, Long> timestamps = new ConcurrentHashMap<>();
+    private static final long CACHE_TTL_MS = 30000; // 30 seconds
+
+    private IsConnectableCache() {}
+
+    public static IsConnectableCache getInstance() {
+        return INSTANCE;
+    }
+
+    public void put(String macAddress, @Nullable Boolean isConnectable) {
+        if (macAddress != null && isConnectable != null) {
+            String key = macAddress.toUpperCase();
+            cache.put(key, isConnectable);
+            timestamps.put(key, System.currentTimeMillis());
+        }
+    }
+
+    @Nullable
+    public Boolean get(String macAddress) {
+        if (macAddress == null) {
+            return null;
+        }
+
+        String key = macAddress.toUpperCase();
+        Long timestamp = timestamps.get(key);
+
+        if (timestamp != null && System.currentTimeMillis() - timestamp > CACHE_TTL_MS) {
+            cache.remove(key);
+            timestamps.remove(key);
+            return null;
+        }
+
+        return cache.get(key);
+    }
+
+    public void clear() {
+        cache.clear();
+        timestamps.clear();
+    }
+}

--- a/android/library/src/main/java/com/polidea/multiplatformbleadapter/utils/NativeScanCallbackWrapper.java
+++ b/android/library/src/main/java/com/polidea/multiplatformbleadapter/utils/NativeScanCallbackWrapper.java
@@ -1,0 +1,43 @@
+package com.polidea.multiplatformbleadapter.utils;
+
+import android.bluetooth.le.ScanCallback;
+import android.bluetooth.le.ScanResult;
+import android.os.Build;
+import android.support.annotation.RequiresApi;
+
+import java.util.List;
+
+/**
+ * Native Android BLE ScanCallback that captures isConnectable information.
+ * Works alongside RxAndroidBle to capture native ScanResult data.
+ */
+@RequiresApi(api = Build.VERSION_CODES.LOLLIPOP)
+public class NativeScanCallbackWrapper extends ScanCallback {
+
+    @Override
+    public void onScanResult(int callbackType, ScanResult result) {
+        super.onScanResult(callbackType, result);
+        captureIsConnectable(result);
+    }
+
+    @Override
+    public void onBatchScanResults(List<ScanResult> results) {
+        super.onBatchScanResults(results);
+        for (ScanResult result : results) {
+            captureIsConnectable(result);
+        }
+    }
+
+    @RequiresApi(api = Build.VERSION_CODES.O)
+    private void captureIsConnectable(ScanResult result) {
+        if (result == null || result.getDevice() == null) {
+            return;
+        }
+
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            String macAddress = result.getDevice().getAddress();
+            boolean isConnectable = result.isConnectable();
+            IsConnectableCache.getInstance().put(macAddress, isConnectable);
+        }
+    }
+}

--- a/android/library/src/main/java/com/polidea/multiplatformbleadapter/utils/mapper/RxScanResultToScanResultMapper.java
+++ b/android/library/src/main/java/com/polidea/multiplatformbleadapter/utils/mapper/RxScanResultToScanResultMapper.java
@@ -1,20 +1,30 @@
 package com.polidea.multiplatformbleadapter.utils.mapper;
 
+import android.os.Build;
+
 import com.polidea.multiplatformbleadapter.AdvertisementData;
 import com.polidea.multiplatformbleadapter.ScanResult;
 import com.polidea.multiplatformbleadapter.utils.Constants;
+import com.polidea.multiplatformbleadapter.utils.IsConnectableCache;
 
 public class RxScanResultToScanResultMapper {
 
     public ScanResult map(com.polidea.rxandroidble.scan.ScanResult rxScanResult) {
+        String macAddress = rxScanResult.getBleDevice().getMacAddress();
+        Boolean isConnectable = null;
+
+        // Get isConnectable from cache (populated by native scan callback)
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            isConnectable = IsConnectableCache.getInstance().get(macAddress);
+        }
+
         return new ScanResult(
-                rxScanResult.getBleDevice().getMacAddress(),
+                macAddress,
                 rxScanResult.getBleDevice().getName(),
                 rxScanResult.getRssi(),
                 Constants.MINIMUM_MTU,
-                false, //isConnectable flag is not available on Android
-                null, //overflowServiceUUIDs are not available on Android
-                AdvertisementData.parseScanResponseData(rxScanResult.getScanRecord().getBytes())
-        );
+                isConnectable,
+                null, // overflowServiceUUIDs are not available on Android
+                AdvertisementData.parseScanResponseData(rxScanResult.getScanRecord().getBytes()));
     }
 }


### PR DESCRIPTION
## Summary
Added support for the `isConnectable` property on Android API 26+ devices. Uses a dual-scanner approach where a native `BluetoothLeScanner` runs alongside RxAndroidBle to capture `isConnectable` values in a thread-safe cache, which are then retrieved when creating `ScanResult` objects.

## Context

ticket: MW-25188